### PR TITLE
Add modify responseBody feature to Firefox.

### DIFF
--- a/build/locales/original.json
+++ b/build/locales/original.json
@@ -108,6 +108,10 @@
 		"message": "Exclude rule",
 		"description": "Label for exclude rule in modal"
 	},
+	"encoding": {
+		"message": "Response body Encoding",
+		"description": "Label for responseBody's character encoding"
+	},
 	"exec_function": {
 		"message": "Custom function",
 		"description": "Custom function in execute type"
@@ -267,6 +271,10 @@
 	"rule_modifyReceiveHeader": {
 		"message": "Modify response header",
 		"description": "Response header option in modal"
+	},
+	"rule_modifyReceiveBody": {
+		"message": "Modify response body",
+		"description": "Response body option in modal"
 	},
 	"rule_modifySendHeader": {
 		"message": "Modify request header",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"vue-template-compiler": "^2.5.17",
 		"webpack": "^4.16.5",
 		"webpack-chrome-extension-reloader": "^0.8.3",
-		"webpack-cli": "^3.1.0"
+		"webpack-cli": "^3.1.0",
+		"text-encoding": "^0.7.0"
 	}
 }

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -214,8 +214,11 @@ function init() {
 		if (cache.receiveHeader === null) {
 			queue.push(updateCache('receiveHeader'));
 		}
+		if (cache.receiveBody === null) {
+			queue.push(updateCache('receiveBody'));
+		}
 		Promise.all(queue).then(() => {
-			if (cache.request === null || cache.sendHeader === null || cache.receiveHeader === null) {
+			if (cache.request === null || cache.sendHeader === null || cache.receiveHeader === null || cache.receiveBody === null) {
 				init();
 			}
 		});

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -6,7 +6,7 @@ import notify from './notify';
 
 function getDatabase() {
 	return new Promise((resolve, reject) => {
-		const dbOpenRequest = window.indexedDB.open("headereditor", 3);
+		const dbOpenRequest = window.indexedDB.open("headereditor", 4);
 		dbOpenRequest.onsuccess = function(e) {
 			resolve(e.target.result);
 		};
@@ -23,6 +23,10 @@ function getDatabase() {
 			} else {
 				utils.TABLE_NAMES.forEach(k => {
 					const tx = event.target.transaction;
+					if(!tx.objectStoreNames.contains(k)){
+						event.target.result.createObjectStore(k, {keyPath: 'id', autoIncrement: true});
+						return;
+					}
 					const os = tx.objectStore(k);
 					os.openCursor().onsuccess = function(e) {
 						const cursor = e.target.result;

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -20,7 +20,7 @@ export default {
 	IS_CHROME: IS_CHROME,
 	CHROME_VERSION: CHROME_VERSION,
 	FIREFOX_VERSION: FIREFOX_VERSION,
-	TABLE_NAMES: ['request', 'sendHeader', 'receiveHeader'],
+	TABLE_NAMES: ['request', 'sendHeader', 'receiveHeader', 'receiveBody'],
 	getExportName(additional) {
 		return 'HE_' + dateFormat(new Date(), 'isoUtcDateTime').replace(/\:/g, '-') + (additional ? "_" + additional : "") + '.json';
 	},
@@ -92,6 +92,9 @@ export default {
 		}
 		if (ruleType === 'modifyReceiveHeader') {
 			return 'receiveHeader';
+		}
+		if (ruleType === 'modifyReceiveBody') {
+			return 'receiveBody';
 		}
 	},
 	upgradeRuleFormat(s) {

--- a/src/options/options.less
+++ b/src/options/options.less
@@ -45,6 +45,10 @@ body {
 		}
 	}
 
+	.md-table-row.unsupported{
+		opacity: .5;
+	}
+
 	.md-table-cell {
 		font-size: 15px;
 		line-height: 30px;
@@ -87,6 +91,19 @@ body.batch-on .group-item .cell-batch {
 }
 
 .rule-drag-view {
+	display: flex;
+	flex-direction: column;
+	max-height: 100vh;
+	.md-card-content,
+	.md-card-area {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+		padding-block-end: 0;
+	}
+	p, pre {
+		margin-block-start: 0;
+	}
 	pre {
 		overflow: auto;
 	}


### PR DESCRIPTION
据我所知目前只有 Firefox 支持 `StreamFilter`，
所以该 pr 只给 Firefox 添加修改响应体的功能。
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter
另外由于原生的 `TextEncoder` 不支持编码成 `utf-8` 以外的编码，
https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder
所以引入了 `text-encoding` 模块。

Firefox 下添加规则界面：
![image](https://user-images.githubusercontent.com/7744663/68573275-61307480-04a2-11ea-96aa-2e87064db632.png)
其中 `响应体编码` 要用户主动设置正确的编码（省却值为 `utf-8`），
否则文本编码解码失败，会导致替换失败或者替换后网页乱码。
（现今新网站大多为 `utf-8`，但国内少部分古老网站依然为 `gbk`）
执行类型为了减少数据库储存字段，所以只支持自定义函数。

不支持 `StreamFilter` 的浏览器（如: Chrome） 添加规则界面保持不变：
![image](https://user-images.githubusercontent.com/7744663/68573756-4f030600-04a3-11ea-8b9f-a7a5198f6137.png)
并且当用户导入了该类型的规则后，
规则管理界面该项会半透明显示表示不可用，并禁止点击 `编辑` 规则。
![image](https://user-images.githubusercontent.com/7744663/68573843-8c679380-04a3-11ea-9161-584cddbe552b.png)


上述规则替换效果：
![image](https://user-images.githubusercontent.com/7744663/68574226-60004700-04a4-11ea-952e-4bfe5422bd53.png)
