### PR TITLE
bugfix

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -260,7 +260,7 @@ class RequestHandler {
 			time: request.timeStamp,
 		};
 
-		['originUrl', 'documentUrl', 'statusCode', 'statusLine', 'requestHeaders', 'responseHeaders'].forEach(p => {
+		['originUrl', 'documentUrl', 'statusCode', 'statusLine'].forEach(p => {
 			if (p in request) {
 				details[p] = request[p];
 			}
@@ -327,6 +327,10 @@ class RequestHandler {
 		}
 
 		const detail = this._makeDetails(e);
+		if(this.includeHeaders){
+			detail.responseHeaders = e.responseHeaders;
+			detail.requestHeaders = e.requestHeaders;
+		}
 
 		const filter = browser.webRequest.filterResponseData(e.requestId);
 		let buffers = null;


### PR DESCRIPTION
这个是先前
https://github.com/FirefoxBar/HeaderEditor/commit/1f1a2343d8cd21c3f403af8fd8550135f11d4b2b#diff-961641dd6af66f5e3313307cf4eb8f1dL242-R327
的更改引入的，没注意还以为`requestHeaders: null` 是多余的，
于是直接在下面复制加上了。

另外我不清楚 `_modifyReceivedBody` 中的 `detail` 是否可以直接加上 `responseHeaders`、`requestHeaders`。
因为我还没搞清楚需要`savedRequestHeader`缓存 headers 的原因。