### PR TITLE
fix getURL

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -71,7 +71,7 @@ function openURL(options) {
 if (typeof(browser.contextMenus) !== 'undefined') {
 	browser.contextMenus.onClicked.addListener((info, tab) => {
 		if (info.menuItemId === 'add-anti-hot-link') {
-			openURL({ url: browser.extension.getURL("options/options.html") + '?action=add-anti-hot-link&url=' + info.srcUrl });
+			openURL({ url: browser.runtime.getURL("options/options.html") + '?action=add-anti-hot-link&url=' + info.srcUrl });
 		}
 	});
 }
@@ -145,7 +145,7 @@ class RequestHandler {
 			return false;
 		}
 		//判断是否是HE自身
-		if (this.excludeHe && e.url.indexOf(browser.extension.getURL('')) === 0) {
+		if (this.excludeHe && e.url.indexOf(browser.runtime.getURL('')) === 0) {
 			return false;
 		}
 		return true;

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -124,7 +124,7 @@ export default {
 			return false;
 		}
 		// other extensions can't be styled
-		if ((url.indexOf("moz-extension") === 0 || url.indexOf("chrome-extension") === 0) && url.indexOf(browser.extension.getURL("")) !== 0) {
+		if ((url.indexOf("moz-extension") === 0 || url.indexOf("chrome-extension") === 0) && url.indexOf(browser.runtime.getURL("")) !== 0) {
 			return false;
 		}
 		if (IS_CHROME && url.indexOf('https://chrome.google.com/webstore') === 0) {

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -19,7 +19,7 @@ export default {
 	methods: {
 		t: utils.t,
 		openManage() {
-			browser.runtime.sendMessage({"method": "openURL", "url": browser.extension.getURL('options/options.html')});
+			browser.runtime.sendMessage({"method": "openURL", "url": browser.runtime.getURL('options/options.html')});
 			window.close();
 		}
 	},


### PR DESCRIPTION
`browser.extension.getURL` [is deprecated](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL), use `browser.runtime.getURL`  instead.

Related Issue: https://github.com/FirefoxBar/HeaderEditor/issues/202