### PR TITLE
fix: fix the issue  that cannot disable target rule when using the `dnr` request handler

### DIFF
--- a/src/pages/background/request-handler/dnr-handler.ts
+++ b/src/pages/background/request-handler/dnr-handler.ts
@@ -191,7 +191,7 @@ class DNRRequestHandler {
         command.removeRuleIds!.push(old);
       }
       // detect new rule is DNR or not
-      if (detectRunner(target) === 'dnr') {
+      if (detectRunner(target) === 'dnr' && target.enable) {
         command.addRules!.push(createDNR(target, getRuleId(target.id, undefined, target.ruleType)));
       }
       if (IS_DEV) {


### PR DESCRIPTION
See:

Once the target rule enabled(In fact, should say "recorded"), it cannot be disabled anymore except deleting it.

![issue demo](https://github.com/user-attachments/assets/4fede09d-87a1-4e90-8439-529b1363f661)
